### PR TITLE
Renaming SERVERS to HOSTS.

### DIFF
--- a/libexec/app_config
+++ b/libexec/app_config
@@ -41,7 +41,9 @@ fi
 
 # Deliver used to be single-server, accounting for that here
 #
-SERVERS=$(__remote_friendly "$SERVER $SERVERS")
+__add_to_deprecations "SERVERS" "v0.8.0"
+SERVERS=$(__remote_friendly "$SERVER $SERVERS $HOSTS")
+HOSTS="$SERVERS"
 
 if [ -z "$LOG_FILE" ]
 then

--- a/libexec/common
+++ b/libexec/common
@@ -20,7 +20,7 @@ nothing_to_do() {
 }
 
 authorize_hosts() {
-  if [ -n "$SERVERS" ]
+  if [ -n "$HOSTS" ]
   then
     status "Authorizing hosts"
 
@@ -29,7 +29,7 @@ authorize_hosts() {
       touch ~/.ssh/known_hosts
     fi
 
-    for _host in $SERVERS
+    for _host in $HOSTS
     do
       if [[ $(ssh-keygen -F $_host | grep -c found) = 0 ]]
       then
@@ -46,7 +46,7 @@ init_app_remotely() {
 
   status "Ensuring remotes are ready to accept git pushes"
 
-  for _host in $SERVERS_APP_USER
+  for _host in $HOSTS_APP_USER
   do
     local _remote_url="$_host:$DELIVER_TO"
     if [[ ! "$git_remote" =~ "$_host $_remote_url" ]]; then
@@ -71,7 +71,7 @@ init_app_remotely() {
 git_push() {
   __exec_if_defined "pre_git_push"
 
-  local _hosts="${1:-"$SERVERS_APP_USER"}"
+  local _hosts="${1:-"$HOSTS_APP_USER"}"
 
   status "Pushing new commits with git to: $_hosts"
 
@@ -224,7 +224,7 @@ launch() {
     sudo rm -f /etc/init/$APP[.-]*
     sudo mv -f $DELIVER_TO/tmp/*conf /etc/init/
     sudo start $APP $SILENCE
-  " "$SERVERS"
+  " "$HOSTS"
 
   __exec_if_defined "post_launch"
 }

--- a/libexec/core
+++ b/libexec/core
@@ -28,20 +28,21 @@ __remote_friendly() {
 # until we're ready to overwrite everything set from other sources
 #
 __capture_runtime_configs() {
-  RUNTIME_SERVERS="$(__remote_friendly "$SERVER $SERVERS")"
+  # DEPRECATE as of v0.8.0
+  RUNTIME_SERVERS="$(__remote_friendly "$SERVER $SERVERS $HOSTS")"
+  RUNTIME_HOSTS="$RUNTIME_SERVERS"
   RUNTIME_BRANCH="$BRANCH"
   RUNTIME_LOG_FILE="$LOG_FILE"
   RUNTIME_APP="$APP"
   RUNTIME_STRATEGY="$STRATEGY"
 }
 
-# If STRATEGY or SERVERS are specified at the time of invoking, overwrite
-# anything that has been set from other sources
+# Overwrite the following configs if they have been specified at runtime:
 #
 __apply_runtime_configs() {
-  if [ -n "$RUNTIME_SERVERS" ]
+  if [ -n "$RUNTIME_HOSTS" ]
   then
-    SERVERS="$RUNTIME_SERVERS"
+    HOSTS="$RUNTIME_HOSTS"
   fi
 
   if [ -n "$RUNTIME_BRANCH" ]
@@ -71,7 +72,7 @@ __apply_runtime_configs() {
 # just a function calling deliver behind the scenes. Imagine the following:
 #
 #   deploy() {
-#     APP=awesome SERVER=ruby-1 PORT=5000 deliver
+#     APP=awesome HOSTS=ruby-1 PORT=5000 deliver
 #   }
 #
 __load_app_config() {
@@ -127,15 +128,15 @@ __load_strategy() {
 }
 
 # Appends app user to all hosts so that we can log in with this user
-# on specific remote jobs. Formats all servers in a format parallel can work with.
+# on specific remote jobs.
 #
 __remote_hosts() {
-  for server in $SERVERS
+  for _host in $HOSTS
   do
-    SERVERS_APP_USER="$SERVERS_APP_USER,$APP_USER@$server"
+    HOSTS_APP_USER="$HOSTS_APP_USER,$APP_USER@$_host"
   done
-  SERVERS="$(__remote_friendly $SERVERS)"
-  SERVERS_APP_USER="$(__remote_friendly $SERVERS_APP_USER)"
+  HOSTS="$(__remote_friendly $HOSTS)"
+  HOSTS_APP_USER="$(__remote_friendly $HOSTS_APP_USER)"
 }
 
 __check_config() {
@@ -228,7 +229,7 @@ __monitor_background_jobs() {
 #
 __parallelize() {
   local _job="$1"
-  local _hosts="${2:-"$SERVERS_APP_USER"}"
+  local _hosts="${2:-"$HOSTS_APP_USER"}"
 
   background_job_pids=()
   background_jobs=()
@@ -259,7 +260,7 @@ __remote() {
   #__parallelize "ssh -o ConnectTimeout=$SSH_TIMEOUT \"\$_host\" \"$_remote_job\""
 
   local _remote_job="$1"
-  local _hosts="${2:-"$SERVERS_APP_USER"}"
+  local _hosts="${2:-"$HOSTS_APP_USER"}"
   background_jobs_pids=()
   background_jobs=()
 

--- a/libexec/init
+++ b/libexec/init
@@ -29,7 +29,7 @@ ${txtbld}Options:${txtrst}
 ${txtbld}Miscellaneous:${txtrst}
   You can overwrite any config at runtime (deliver check):
 
-  SERVER=ruby-1-local PORT=6000 deliver -V
+  HOSTS=ruby-1-local PORT=6000 deliver -V
 "
 }
 

--- a/strategies/generated
+++ b/strategies/generated
@@ -9,7 +9,7 @@
 # Every deploy is a commit on the generated branch. This then gets pushed out
 # to all remote hosts (or just to github:pages).
 
-OPTIONAL_CONFIGS+=("GENERATED_DIR" "GENERATED_BRANCH" "GENERATE_CMD" "SERVERS")
+OPTIONAL_CONFIGS+=("GENERATED_DIR" "GENERATED_BRANCH" "GENERATE_CMD" "HOSTS")
 
 BRANCH="$GENERATED_BRANCH"
 

--- a/strategies/nodejs
+++ b/strategies/nodejs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-REQUIRED_CONFIGS+=("SERVERS")
+REQUIRED_CONFIGS+=("HOSTS")
 
 run() {
   authorize_hosts

--- a/strategies/ruby
+++ b/strategies/ruby
@@ -3,14 +3,12 @@
 # This is the default deliver strategy.
 # It uses git push, rvm & foreman to generate upstart jobs
 
-REQUIRED_CONFIGS+=("SERVERS")
+REQUIRED_CONFIGS+=("HOSTS")
 
 # This function must be present since deliver will call it directly
 # Everything inside it or around it are only limited by your imagination : )
 #
 run() {
-  # TODO
-  # If remote is up-to-date, finish early
   authorize_hosts
   init_app_remotely
   git_push

--- a/test/args_test.rb
+++ b/test/args_test.rb
@@ -53,13 +53,13 @@ class TestDeliverArgs < MiniTest::Unit::TestCase
   )
 
   deliver(
-    :vars   => "SERVER='localhost'",
+    :vars   => "HOSTS='localhost'",
     :args   => "check",
     :output => %r{
       APP.+deliver.+
-      APP_ROOT.+deliver.+
+      ORIGIN_DIR.+deliver.+
       STRATEGY.+ruby.+
-      SERVERS.+[^,]localhost[^,].+
+      HOSTS.+[^,]localhost[^,].+
       READY.TO.DELIVER
     }xm
   )


### PR DESCRIPTION
I clearly wasn't in my best of naming moods when I settled on **SERVERS**.

I was thinking about **INSTANCES** as well (`$HOST` is reserved, as is `$hosts` in OS X), but in the end decided to drop `$HOST` and just stick with `$HOSTS`. **INSTANCES** feels too AWS-ish.
