### PR TITLE
Tiny guard for when the app is not using rvm.

### DIFF
--- a/libexec/common
+++ b/libexec/common
@@ -130,16 +130,19 @@ git_submodules() {
 }
 
 rvmrc_trust() {
-  __exec_if_defined "pre_rvmrc_trust"
+  if [ -e "$ORIGIN_DIR/.rvmrc" ]
+  then
+    __exec_if_defined "pre_rvmrc_trust"
 
-  status "Trusting rvmrc in $DELIVER_TO"
-  __remote "
-    set -e
-    source .profile
-    rvm rvmrc trust $DELIVER_TO $SILENCE
-  "
+    status "Trusting rvmrc in $DELIVER_TO"
+    __remote "
+      set -e
+      source .profile
+      rvm rvmrc trust $DELIVER_TO $SILENCE
+    "
 
-  __exec_if_defined "post_rvmrc_trust"
+    __exec_if_defined "post_rvmrc_trust"
+  fi
 }
 
 authorize_remote_hosts() {


### PR DESCRIPTION
If an .rvmrc file is not present locally, it won't bother sourcing it in production.

You should deliver from the branch that you're intending to push out.

You should version .rvmrc files in the app, do not generate them on the remote hosts.
