### PR TITLE
Reset all submodules before update to avoid conflicts

### DIFF
--- a/libexec/common
+++ b/libexec/common
@@ -122,6 +122,7 @@ git_submodules() {
         system(command)
         close(command)
       }'
+      git submodule foreach 'git reset --hard $SILENCE' $SILENCE
       git submodule update $SILENCE
     fi
   "


### PR DESCRIPTION
Doing a `git submodule update` breaks in the situation where files have been changed inside the submodule. Git's man pages suggest there's a `git submodule update -f` but it doesn't exist. Doing a `git  reset --hard` inside each submodule seems to work.
