### PR TITLE
Append to PATH, don't prepend

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ $ git clone git://github.com/gerhard/deliver.git ~/.deliver
 ### 1.2 Add `~/.deliver/bin` to your `$PATH` for access to the `deliver` command-line utility
 
 ```bash
-$ echo 'export PATH="$HOME/.deliver/bin:$PATH"' >> ~/.bash_profile
+$ echo 'export PATH="${PATH}:$HOME/.deliver/bin"' >> ~/.bash_profile
 # if using zsh
-$ echo 'export PATH="$HOME/.deliver/bin:$PATH"' >> ~/.zshrc 
+$ echo 'export PATH="${PATH}:$HOME/.deliver/bin"' >> ~/.zshrc
 ```
 
 ### 1.3 Source your shell profile


### PR DESCRIPTION
When deliver's `bin/` directory is prepended to the `PATH`, any binaries
it provides have higher priority than system ones, for example `/bin/ls`

This is kind of scary as future updates to this repository could provide
evil replacements of common system commands - a fab way of owning users.
